### PR TITLE
Remove unneeded configuration in buildPlugin

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,1 @@
-node {
-    stage('Build') {
-        buildPlugin(findbugs: [archive: true, unstableTotalAll: '100'])
-    }
-}
+buildPlugin()


### PR DESCRIPTION
Spotbugs reporting is being enabled by default in https://github.com/jenkins-infra/pipeline-library/pull/121, update to parent pom 4.x to use spotbugs instead of findbugs.